### PR TITLE
Added import of requests lib

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,7 @@ runs:
   using: "composite"
   steps:
     - run: |
+        python -m pip install requests
         python $GITHUB_ACTION_PATH/result_report.py ${{ inputs.output_file }} report.md ${{ inputs.endpoints }} ${{ inputs.username }} ${{ inputs.password }}
         cat report.md >> $GITHUB_STEP_SUMMARY
       shell: bash


### PR DESCRIPTION
In certain workflows, the requests library seemed to be missing, so I've added an explicit install in the action.

Example of such a workflow: https://github.com/minvws/nl-rdo-woo-web-private/actions/runs/9637411208/job/26586485888#step:10:29

Successful run using this branch: https://github.com/minvws/nl-rdo-woo-web-private/actions/runs/9641802739/job/26588229433#step:10:14