### PR TITLE
Add icon for skipped tests

### DIFF
--- a/result_report.py
+++ b/result_report.py
@@ -76,6 +76,8 @@ class ResultReport(ResultVisitor):
                     f.write(":red_circle:|\n")
                 elif test.status == 'PASS':
                     f.write(":green_circle:|\n")
+                elif test.status == 'SKIP':
+                    f.write(":white_circle:|\n")
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
This run has skipped tests, but no icon is shown:

<img width="1389" alt="image" src="https://github.com/user-attachments/assets/23e314c3-d26b-4a99-9132-34d3512337f9" />

This PR adds a white circle icon.