### PR TITLE
Add robotframework dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .venv
 report.md
+.idea/*

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
   steps:
     - run: |
-        python -m pip install requests
+        python -m pip install requests robotframework
         python $GITHUB_ACTION_PATH/result_report.py ${{ inputs.output_file }} report.md ${{ inputs.endpoints }} ${{ inputs.username }} ${{ inputs.password }}
         cat report.md >> $GITHUB_STEP_SUMMARY
       shell: bash


### PR DESCRIPTION
When using this plugin, if `robot` is not available in the pipeline where you use it then it complains that the `module robot is not found`. Instead of installing robot in the pipeline where used, we are installing robot for this plugin to work. Since anyways its a dependency for this plugin.

you can try this branch like this:
```        uses: minvws/nl-rdo-github-action-robotframework-test-summary@add-robotframework-dependency ```
this is an example run (plz note we call the plugin twice on that workflow)
https://github.com/minvws/nl-mgo-coordination-private/actions/runs/16619923324?pr=352