### PR TITLE
ci: add major-version-tag workflow

### DIFF
--- a/.github/workflows/major-version-tag.yml
+++ b/.github/workflows/major-version-tag.yml
@@ -1,0 +1,19 @@
+name: Major version tag
+
+on:
+  workflow_dispatch:
+  push:
+    tags: ["v[0-9]+.*"]
+
+jobs:
+  major-version-tag:
+    name: Major version tag
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Create or update major version tag
+        uses: minvws/action-major-version-tag@v1


### PR DESCRIPTION
Automatically create or update the major version tag (e.g. `v1`) when a new version tag (e.g. `v1.2.3`) is pushed.

Depends on minvws/action-major-version-tag#1.
